### PR TITLE
Add support for Passport branding

### DIFF
--- a/lib/omniauth-passport/version.rb
+++ b/lib/omniauth-passport/version.rb
@@ -1,5 +1,5 @@
 module Omniauth
   module Passport
-    VERSION = "0.0.7"
+    VERSION = "0.0.6"
   end
 end


### PR DESCRIPTION
Passing params to the endpoint will incorporate them into the
authorisation request which is then used by Passport.
